### PR TITLE
Update `flake.nix` to use `inputs` rather than `fetchFromGithub`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ flake. By default, it updates the flake lockfile and the vendorHash for the tip
 of dolt/main. To do so, just run:
 
 ```
-go run .
+nix develop -i -c 'dolt-nix-flake'
 ```
 
 and checkin the result.
@@ -17,7 +17,7 @@ You can also update the flake to be for a given dolt release. To do so, run
 something like:
 
 ```
-go run . --revision '?ref=tags/v1.20.0'
+nix develop -i -c dolt-nix-flake --revision '?ref=tags/v1.20.0'
 ```
 
 The result should be pushed to release tag corresponding to the given dolt

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "dolt": {
       "flake": false,
       "locked": {
-        "lastModified": 1697874886,
-        "narHash": "sha256-EU/JBi3sAmNeo4bCndgcP2evDKzMroLiZtAPdqz5Xio=",
+        "lastModified": 1698187230,
+        "narHash": "sha256-pa9xsbO/d5/3wCx2XKn4dzlqPlO3Ie/cGJiwfWTEUKc=",
         "owner": "dolthub",
         "repo": "dolt",
-        "rev": "41a47d9b8e102423aa4fc7a26075813d464d8b7a",
+        "rev": "17937a905af10022c9efa1273c61f334bdb416b7",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685620773,
-        "narHash": "sha256-iQ+LmporQNdLz8uMJdP62TaAWeLUwl43/MYUBtWqulM=",
-        "path": "/nix/store/ipbqg8zvymxjlw96pl2mvgpigzc3wm7p-source",
-        "rev": "f0ba8235153dd2e25cf06cbf70d43efdd4443592",
-        "type": "path"
+        "lastModified": 1697915759,
+        "narHash": "sha256-WyMj5jGcecD+KC8gEs+wFth1J1wjisZf8kVZH13f1Zo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "51d906d2341c9e866e48c2efcaac0f2d70bfd43e",
+        "type": "github"
       },
       "original": {
         "id": "nixpkgs",

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "dolt": {
       "flake": false,
       "locked": {
-        "lastModified": 1697525937,
-        "narHash": "sha256-X8wOP7xrKka4bUH+ZltYZM1JaC0ZhOuRzRqz6hKrgZ4=",
+        "lastModified": 1697874886,
+        "narHash": "sha256-EU/JBi3sAmNeo4bCndgcP2evDKzMroLiZtAPdqz5Xio=",
         "owner": "dolthub",
         "repo": "dolt",
-        "rev": "e3fd68c6501cceeb6b3b47c4b9fcaec41d5c54b7",
+        "rev": "41a47d9b8e102423aa4fc7a26075813d464d8b7a",
         "type": "github"
       },
       "original": {
@@ -36,12 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697379843,
-        "narHash": "sha256-RcnGuJgC2K/UpTy+d32piEoBXq2M+nVFzM3ah/ZdJzg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "12bdeb01ff9e2d3917e6a44037ed7df6e6c3df9d",
-        "type": "github"
+        "lastModified": 1685620773,
+        "narHash": "sha256-iQ+LmporQNdLz8uMJdP62TaAWeLUwl43/MYUBtWqulM=",
+        "path": "/nix/store/ipbqg8zvymxjlw96pl2mvgpigzc3wm7p-source",
+        "rev": "f0ba8235153dd2e25cf06cbf70d43efdd4443592",
+        "type": "path"
       },
       "original": {
         "id": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,16 @@
       lib = nixpkgs.lib;
     in
     {
+      devShells.default = pkgs.mkShell {
+        buildInputs = [
+          self.packages.${system}.dolt-nix-flake
+          pkgs.nix
+          pkgs.unzip
+          pkgs.go
+          pkgs.git
+        ];
+      };
+
       packages.dolt-nix-flake = pkgs.buildGoModule {
         name = "dolt-nix-flake";
         pname = "dolt-nix-flake";
@@ -32,7 +42,7 @@
         src = dolt;
         modRoot = "./go";
         subPackages = [ "cmd/dolt" ];
-        vendorHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+        vendorHash = "sha256-1Cy0PmDmMPpPZ2PLDP6sywb39MuExv2yabqSeP3Of9M=";
         proxyVendor = true;
         doCheck = false;
 

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,15 @@
       lib = nixpkgs.lib;
     in
     {
+      packages.dolt-nix-flake = pkgs.buildGoModule {
+        name = "dolt-nix-flake";
+        pname = "dolt-nix-flake";
+
+        src = ./.;
+        modRoot = ".";
+        vendorHash = null;
+      };
+
       packages.default = pkgs.buildGoModule {
         name = "dolt";
 
@@ -23,7 +32,7 @@
         src = dolt;
         modRoot = "./go";
         subPackages = [ "cmd/dolt" ];
-        vendorHash = "sha256-jrHrv08mwjq4a8gDlrhUe+A7qMFzcdhW/cZFQPcAQ94=";
+        vendorHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
         proxyVendor = true;
         doCheck = false;
 

--- a/flake.nix.template
+++ b/flake.nix.template
@@ -14,6 +14,15 @@
       lib = nixpkgs.lib;
     in
     {
+      packages.dolt-nix-flake = pkgs.buildGoModule {
+        name = "dolt-nix-flake";
+        pname = "dolt-nix-flake";
+
+        src = ./.;
+        modRoot = ".";
+        vendorHash = null;
+      };
+
       packages.default = pkgs.buildGoModule {
         name = "dolt";
 

--- a/flake.nix.template
+++ b/flake.nix.template
@@ -14,6 +14,16 @@
       lib = nixpkgs.lib;
     in
     {
+      devShells.default = pkgs.mkShell {
+        buildInputs = [
+          self.packages.${system}.dolt-nix-flake
+          pkgs.nix
+          pkgs.unzip
+          pkgs.go
+          pkgs.git
+        ];
+      };
+
       packages.dolt-nix-flake = pkgs.buildGoModule {
         name = "dolt-nix-flake";
         pname = "dolt-nix-flake";

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/dolthub/dolt-nix-flake
 
-go 1.21.2
+go 1.21

--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func main() {
 
 	nixprog, err := exec.LookPath("nix")
 	if err != nil {
-		panic(fmt.Errorf("did not find required executable, nix-hash, in PATH: %v", err))
+		panic(fmt.Errorf("did not find required executable, nix, in PATH: %v", err))
 	}
 
 	err = WriteFlake(*RevisionSegment, FakeNarHash)
@@ -217,9 +217,9 @@ func NixHashDir(prog, dir string) (string, error) {
 
 func NixFlakeUpdate(prog string) error {
 	cmd := exec.Command(prog, "flake", "update")
-	err := cmd.Run()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("could not run `nix flake update`: %w", err)
+		return fmt.Errorf("could not run `nix flake update`: %w\n\n%s", err, string(out))
 	}
 	return nil
 }


### PR DESCRIPTION
This handles dependencies in the more idiomatic "flake" way. The particular revision you're referencing will be stored in the `flake.lock` file, but if you need to reference a particular branch or revision, you can do so explictly as well:

```nix
# Get the latest revision from the main branch as of the last call to `nix flake update`
inputs.dolt.url = "github:dolthub/dolt-nix-flake";

# Get the latest revision from the "taylor/create-dolt-docs" branch as of the last call to `nix flake update`
inputs.dolt.url = "github:dolthub/dolt-nix-flake?ref=taylor/create-dolt-docs";


# Get revision "https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html#examples" 
inputs.dolt.url = "github:dolthub/dolt-nix-flake/41237a70c9c065f8220322bde383ba43135433b7";
```

You can see more examples [In the docs](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html#examples).